### PR TITLE
Add real-time clock with SSE and animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/node_modules/
+client-admin/build/
+

--- a/client-admin/src/components/HomeComponent.js
+++ b/client-admin/src/components/HomeComponent.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import RealTimeClock from './RealTimeClock';
 
 class Home extends Component {
   render() {
@@ -13,6 +14,7 @@ class Home extends Component {
         />
         <div>
           <h2 className="font-bold text-8xl">Account Admin</h2>
+          <RealTimeClock />
         </div>
       </div>
     );

--- a/client-admin/src/components/RealTimeClock.js
+++ b/client-admin/src/components/RealTimeClock.js
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import '../css/RealTimeClock.css';
+
+const RealTimeClock = () => {
+  const [time, setTime] = useState('');
+
+  useEffect(() => {
+    const source = new EventSource('/api/time');
+    source.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setTime(data.time);
+      } catch (err) {
+        console.error('Failed to parse time', err);
+      }
+    };
+    return () => {
+      source.close();
+    };
+  }, []);
+
+  return (
+    <div className="mt-4 text-2xl font-mono">
+      <span key={time} className="fade-in">{time}</span>
+    </div>
+  );
+};
+
+export default RealTimeClock;

--- a/client-admin/src/css/RealTimeClock.css
+++ b/client-admin/src/css/RealTimeClock.css
@@ -1,0 +1,8 @@
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.fade-in {
+  animation: fade-in 1s ease-in-out;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,23 @@ app.get('/hello', (req, res) => {
 
 app.use('/api/admin', require('./api/admin.js'));
 app.use('/api/customer', require('./api/customer.js'));
+// Real-time clock endpoint using Server-Sent Events
+app.get('/api/time', (req, res) => {
+  res.set({
+    'Cache-Control': 'no-cache',
+    'Content-Type': 'text/event-stream',
+    'Connection': 'keep-alive',
+  });
+  const sendTime = () => {
+    res.write(`data: ${JSON.stringify({ time: new Date().toISOString() })}\n\n`);
+  };
+  // send initial time and then every second
+  sendTime();
+  const interval = setInterval(sendTime, 1000);
+  req.on('close', () => {
+    clearInterval(interval);
+  });
+});
 // deployment
 const path = require('path');
 // '/admin' serve the files at client-admin/build/* as static files


### PR DESCRIPTION
## Summary
- add Server-Sent Events endpoint that streams current time
- show live time in admin home with fade-in animation
- ignore node_modules and build artifacts

## Testing
- `cd client-admin && npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `cd ../server && npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b80ca2088883268d1a33b4074dccd9