### PR TITLE
Add transition animations to product list tables

### DIFF
--- a/client-admin/src/App.css
+++ b/client-admin/src/App.css
@@ -120,3 +120,54 @@ tr:not(:first-child):hover.datatable {
     background-color: #dcfcfc;
     cursor: pointer;
 }
+
+/* animation utilities */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.fade-in-up {
+    animation: fadeInUp 0.3s ease;
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+.page-transition {
+    animation: slideIn 0.4s ease;
+}
+
+.selected-row {
+    background-color: #dcfcfc !important;
+    transform: scale(1.01);
+    transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.pagination-number {
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+.pagination-number:hover {
+    transform: scale(1.2);
+}
+
+.pagination-number.active {
+    font-weight: bold;
+    transform: scale(1.2);
+}

--- a/client-admin/src/components/ProductComponent.js
+++ b/client-admin/src/components/ProductComponent.js
@@ -29,8 +29,9 @@ class Product extends Component {
   };
   render() {
     const prods = this.state.products.map((item) => {
+      const isSelected = this.state.itemSelected && this.state.itemSelected._id === item._id;
       return (
-        <tr key={item._id} className="datatable" onClick={() => this.trItemClick(item)}>
+        <tr key={item._id} className={`datatable fade-in-up ${isSelected ? 'selected-row' : ''}`} onClick={() => this.trItemClick(item)}>
           <td>{item._id}</td>
           <td>{item.name}</td>
           <td>{item.price}</td>
@@ -40,13 +41,15 @@ class Product extends Component {
         </tr>
       );
     });
-    const pagination = Array.from({ length: this.state.noPages }, (_, index) => {
-      if ((index + 1) === this.state.curPage) {
-        return (<span key={index}>| <b>{index + 1}</b> |</span>);
-      } else {
-        return (<span key={index} className="link" onClick={() => this.lnkPageClick(index + 1)}>| {index + 1} |</span>);
-      }
-    });
+    const pagination = Array.from({ length: this.state.noPages }, (_, index) => (
+      <span
+        key={index}
+        className={`pagination-number fade-in-up ${this.state.curPage === index + 1 ? 'active' : ''}`}
+        onClick={() => this.lnkPageClick(index + 1)}
+      >
+        {index + 1}
+      </span>
+    ));
     return (
       
       <div>
@@ -55,7 +58,7 @@ class Product extends Component {
          <div className="w-[50%]">
           <h2 className="text-center text-2xl font-bold text-red">PRODUCT LIST</h2>
           <table className="datatable mt-3" border="1">
-            <tbody>
+            <tbody key={this.state.curPage} className="page-transition">
               <tr className="datatable">
                 <th>ID</th>
                 <th>Name</th>
@@ -71,12 +74,7 @@ class Product extends Component {
                       {pagination.map((page, index) => (
                         <React.Fragment key={index}>
                           {index > 0 && <span className="pagination-separator "></span>}
-                          <span
-                            className={`pagination-number ${this.state.curPage === index + 1 ? 'active' : ''}`}
-                            onClick={() => this.lnkPageClick(index + 1)}
-                          >
-                            {page}
-                          </span>
+                          {page}
                         </React.Fragment>
                       ))}
                       <span className="pagination-arrow font-bold text-3xl" onClick={this.increasePage}>&gt;</span>


### PR DESCRIPTION
## Summary
- animate table rows with fade-in effect and subtle selection highlighting
- slide/fade pagination controls and table body when changing pages

## Testing
- `CI=true npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b80d22c36483269eb45459a1758318